### PR TITLE
Transition to slash commands.

### DIFF
--- a/Dx2-DiscordBot.csproj
+++ b/Dx2-DiscordBot.csproj
@@ -12,9 +12,9 @@
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="12.1.2" />
     <PackageReference Include="Discord.Net" Version="2.2.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.24" />
-    <PackageReference Include="NLog.Config" Version="4.6.2" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.43" />
+    <PackageReference Include="NLog" Version="5.0.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

This PR aims to update the dependencies to their latest version, this maintenance allows for integration of security patches and anticipate for deprecation.

Most notably:
- `NLog.Config` has been deprecated, in favour of using `NLog` 5 directly.
- Discord is aggressive about moving to slash commands, as such `Discord.Net` requires to be updated to version 3 and update the commands.

## Tasks list 

- [ ] Update CsvHelper (12.1.2 -> 28.0.1), requires minor code adjustment.
- [ ] Update Discord.Net (2.2.0 -> 3.7.2), requires updating commands.
- [X] Update HtmlAgilityPack (1.11.24 -> 1.11.43).
- [X] Replace NLog.Config 4 with NLog 5.
- [X] Update System.Configuration.ConfigurationManager (4.5.0 -> 6.0.0).